### PR TITLE
Check for Editor accessGroup 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-service",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-service",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "description": "",
   "author": "",
   "private": true,

--- a/src/learning-objects/auth/jwt.strategy.ts
+++ b/src/learning-objects/auth/jwt.strategy.ts
@@ -15,9 +15,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   // Validate Access Groups
   async validate(payload: UserToken) {
-    if (payload.accessGroups === undefined || !payload.accessGroups.includes('admin' || 'editor')) {
+    if (payload.accessGroups === undefined || !this.isAdminOrEditor(payload.accessGroups)) {
       throw new UnauthorizedException('You have to be an admin or editor in order to update feature learning objects')
     }
     return payload;
+  }
+
+  // Determine if the requester is an admin or editor
+  isAdminOrEditor(userGroup: string[]): Boolean {
+    return userGroup.includes('editor') || userGroup.includes('admin');
   }
 }


### PR DESCRIPTION
This PR fixes a bug where editors were not authorized to update our featured learning objects which was causing Justine to not be able to feature objects on the homepage. 