### PR TITLE
:whale: [ch3061] Fix Docker Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.env
+deploy.sh
+
+.circleci/
+dist/
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-service",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-service",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "",
   "author": "",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "nest start --watch",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node dist/src/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest --runInBand ./test",
     "test:watch": "jest --watch",


### PR DESCRIPTION
This PR fixes the `start:prod` script so that it references the correct directory, and reworks the Dockerfile to start the container using the `start:prod` script by default.

Output of the container running in docker-compose:
![image](https://user-images.githubusercontent.com/14933100/101122758-0b94a180-35a8-11eb-839d-5fba8aef28f3.png)
