### PR TITLE
3853/create-secured-team-email-domain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "feature-service",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-service",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "author": "",
   "private": true,

--- a/src/services/send-grid/interfaces/mailer.defaults.ts
+++ b/src/services/send-grid/interfaces/mailer.defaults.ts
@@ -1,5 +1,5 @@
 export enum FROM {
-    NO_REPLY = 'CLARK <noreply@clark.center>'
+    NO_REPLY = 'CLARK <noreply@secured.team>'
 }
 export enum SUBJECTS {
     FEATURED_AUTHOR = 'Congratulations!! You have been featured on Clark',


### PR DESCRIPTION
This PR updates the from email to come from the secured.team domain.  Completes story [3853/create-secured-team-email-domain](https://app.clubhouse.io/clarkcan/story/3853/create-secured-team-email-domain).